### PR TITLE
Add Helm Chart releaser job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,33 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+  # just for testing purposes, will be removed
+  workflow_dispatch:
+
+jobs:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          charts_dir: .
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -101,5 +101,3 @@ This fork open in any time to contributors and also open to move into official r
 | wazuh.storageSizeWorker | string | `"50Gi"` |  |
 | wazuh.syslog_enable | bool | `true` |  |
 | wazuh.worker_replicas | int | `2` |  |
-
-


### PR DESCRIPTION
Following steps on ["Chart Releaser Action to Automate GitHub Page Charts"](https://helm.sh/docs/howto/chart_releaser_action/)

Added a Github workflow using the [helm-chart-releaser](https://github.com/marketplace/actions/helm-chart-releaser) action that will make changes in the existing `gh-pages` branch.

I don't have permissions to access the settings in the repository, so if possible @morgoved can you do step 3 from the link above:

> In your repo, go to Settings/Pages. Change the Source Branch to gh-pages.