### PR TITLE
Fix dashboard ingress spec

### DIFF
--- a/charts/wazuh/templates/dashboard/ingress.yaml
+++ b/charts/wazuh/templates/dashboard/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion:  networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: name: {{ include "wazuh.fullname" . }}-dashboard
+  name: {{ include "wazuh.fullname" . }}-dashboard
   labels:
     app: {{ include "wazuh.fullname" . }}-dashboard
   annotations:


### PR DESCRIPTION
Removed a duplicate `name:` that prevented rendering.