### PR TITLE
fix: ca certs is not created if issuer name is specified, whereas the…

### DIFF
--- a/charts/wazuh/templates/certs/certificate.yaml
+++ b/charts/wazuh/templates/certs/certificate.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.certificates.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -138,4 +137,3 @@ spec:
     {{- if eq .Values.certificates.issuer.type "ClusterIssuer" }}
     kind: ClusterIssuer
     {{- end }}
-{{- end }}

--- a/charts/wazuh/templates/certs/issuer.yaml
+++ b/charts/wazuh/templates/certs/issuer.yaml
@@ -1,5 +1,4 @@
 # https://cert-manager.io/docs/configuration/selfsigned/
-{{- if .Values.certificates.enabled }}
 # If the issuer is not specified, a self-signed issuer will be created
 {{- if not .Values.certificates.issuer.name }}
 apiVersion: cert-manager.io/v1
@@ -44,4 +43,3 @@ metadata:
 spec:
   ca:
     secretName: root-secret
-{{- end }}

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -20,7 +20,6 @@ cert-manager:
 ## @section certificates If cert-manager is present, the certificates can be generated automatically.
 ##
 certificates:
-  enabled: true
   ## Parameters for the issuer.
   ##
   issuer:


### PR DESCRIPTION
## Problem

When `certificates.issuer.name` is specified in `values.yaml`, the chart skips creation of the internal self-signed CA resources (`*-selfsigned-issuer`, `*-root-ca`, and `*-ca-issuer`) due to this condition in the templates:

```gotmpl
{{- if not .Values.certificates.issuer.name }}
```
However, downstream Certificate resources (e.g., for the node-tls ) still hardcode a reference to:
```
issuerRef:
  name: {{ include "wazuh.fullname" . }}-ca-issuer
  ```

This leads to broken CertificateRequests because the referenced Issuer does not exist if it was never rendered.

## Fix
This PR updates the chart logic to ensure that each Certificate uses the correct issuerRef based on the values defined in:
```
certificates:
  issuer:
    name: selfsigned-issuer
    type: ClusterIssuer
```
If no custom issuer is defined, it defaults to the internal *-ca-issuer as before, maintaining backward compatibility.

