### PR TITLE
fix: *-node certs Failed to create, caused by certificates.issuer.name is defined

### DIFF
--- a/charts/wazuh/templates/certs/certificate.yaml
+++ b/charts/wazuh/templates/certs/certificate.yaml
@@ -97,7 +97,10 @@ spec:
 
   # Issuer references are always required.
   issuerRef:
-    name: {{ include "wazuh.fullname" . }}-ca-issuer
+    name: {{ .Values.certificates.issuer.name | default (printf "%s-ca-issuer" (include "wazuh.fullname" .)) }}
+    {{- if eq .Values.certificates.issuer.type "ClusterIssuer" }}
+    kind: ClusterIssuer
+    {{- end }}
     # We can reference ClusterIssuers by changing the kind here.
     # The default value is Issuer (i.e. a locally namespaced Issuer)
 ---


### PR DESCRIPTION
## Problem

When `certificates.issuer.name` is specified in `values.yaml`, the chart skips creation of the internal self-signed CA resources (`*-selfsigned-issuer`, `*-root-ca`, and `*-ca-issuer`) due to this condition in the templates:

```
{{- if not .Values.certificates.issuer.name }}
```
However, downstream Certificate resources (e.g., for the -node) still hardcode a reference to:
```
issuerRef:
  name: {{ include "wazuh.fullname" . }}-ca-issuer
```
This leads to broken CertificateRequest resources, because the referenced Issuer does not exist if that template block is skipped.
