### PR TITLE
feat(wazuh-agent): initiate agent deployment on kubernetes

### DIFF
--- a/charts/wazuh/templates/agent/daemonset.yaml
+++ b/charts/wazuh/templates/agent/daemonset.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.agent.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "wazuh.indexer.fullname" . }}-agent
+  labels:
+    app: {{ include "wazuh.indexer.fullname" . }}-agent
+    {{- with .Values.agent.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.agent.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.agent.extraSpec.daemonSet }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ include "wazuh.indexer.fullname" . }}-agent
+      node-type: agent
+  template:
+    metadata:
+      name: {{ include "wazuh.indexer.fullname" . }}-agent
+      {{- with .Values.agent.podAnnotations }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      labels:
+        app: {{ include "wazuh.indexer.fullname" . }}-agent
+        node-type: agent
+    spec:
+      {{- with .Values.agent.extraSpec.pod }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.agent.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agent.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agent.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agent.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: wazuh-agent
+          {{- with .Values.agent.extraSpec.container }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          image: {{ .Values.agent.images.repository }}:{{ .Values.agent.images.tag }}
+          imagePullPolicy: {{ .Values.agent.images.pullPolicy }}
+          ports:
+            - name: agent-http
+              containerPort: {{ .Values.agent.service.port }}
+              protocol: TCP
+          {{- with .Values.agent.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: JOIN_MANAGER
+              value: {{ printf "wazuh.%s.svc.cluster.local" .Release.Namespace }}
+            - name: JOIN_MANAGER_MASTER_HOST
+              value: {{ printf "wazuh.%s.svc.cluster.local" .Release.Namespace }}
+            - name: JOIN_MANAGER_WORKER_HOST
+              value: {{ printf "%s-manager-worker.wazuh.svc.cluster.local" (include "wazuh.fullname" .) }}
+            - name: JOIN_MANAGER_PROTOCOL
+              value: {{ .Values.agent.joinManager.scheme }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: JOIN_MANAGER_USER
+              valueFrom:
+                secretKeyRef:
+                  name: wazuh-api-cred
+                  key: API_USERNAME
+            - name: JOIN_MANAGER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wazuh-api-cred
+                  key: API_PASSWORD
+            - name: JOIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wazuh-api-cred
+                  key: API_PASSWORD
+            - name: WAZUH_GROUPS
+              value: {{ .Values.agent.joinManager.wazuh.group | quote }}
+            - name: JOIN_MANAGER_API_PORT
+              value: {{ .Values.wazuh.master.service.ports.api | quote }}
+            - name: JOIN_MANAGER_PORT
+              value: {{ .Values.wazuh.worker.service.ports.agentEvents | quote }}
+            - name: HEALTH_CHECK_PROCESSES
+              value: "ossec-execd,ossec-syscheckd,ossec-logcollector,wazuh-modulesd,ossec-authd"
+          {{- with .Values.agent.livenessProbe }}
+          livenessProbe:
+            httpGet:
+              path: /healz
+              port: 5000
+            initialDelaySeconds: 40
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 5
+          {{- end }}
+          {{- with .Values.agent.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.agent.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.agent.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/wazuh/templates/agent/service.yaml
+++ b/charts/wazuh/templates/agent/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # Name is only "wazuh" because of Certificates commonName
+  name: {{ include "wazuh.fullname" . }}-agent
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "wazuh.fullname" . }}-agent
+    node-type: agent
+  annotations:
+    {{- toYaml .Values.wazuh.master.service.annotations | nindent 4 }}
+spec:
+  ports:
+    - name: http
+      port: {{ .Values.agent.service.port }}
+      targetPort: {{ .Values.agent.service.port }}
+  selector:
+    app: {{ include "wazuh.fullname" . }}-agent
+    node-type: agent
+  type: {{ .Values.agent.service.type }}

--- a/charts/wazuh/templates/certs/filebeat/certificate.yaml
+++ b/charts/wazuh/templates/certs/filebeat/certificate.yaml
@@ -22,7 +22,9 @@ spec:
       - {{ .Values.certificates.subject.locality }}
   # Issuer references are always required.
   issuerRef:
-    name: {{ .Values.certificates.issuer.name | default (printf "%s-ca-issuer" (include "wazuh.fullname" .)) }}
-    {{- if eq .Values.certificates.issuer.type "ClusterIssuer" }}
-    kind: ClusterIssuer
-    {{- end }}
+    # Admin Issuer have to use the CA Issuer so that the certificate can be validated with node-tls secret
+    name: {{ include "wazuh.fullname" . }}-ca-issuer
+{{/*    name: {{ .Values.certificates.issuer.name | default (printf "%s-ca-issuer" (include "wazuh.fullname" .)) }}*/}}
+{{/*    {{- if eq .Values.certificates.issuer.type "ClusterIssuer" }}*/}}
+{{/*    kind: ClusterIssuer*/}}
+{{/*    {{- end }}*/}}

--- a/charts/wazuh/templates/manager/master/networkpolicy.yaml
+++ b/charts/wazuh/templates/manager/master/networkpolicy.yaml
@@ -23,6 +23,10 @@ spec:
         - podSelector:
             matchLabels:
               app: {{ include "wazuh.fullname" . }}-dashboard
+        - podSelector:
+            matchLabels:
+              app: {{ include "wazuh.fullname" . }}-agent
+              node-type: agent
     - ports:
         - protocol: TCP
           port: {{ .Values.wazuh.service.port }}

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -697,3 +697,177 @@ wazuh:
       statefulSet: {}
       pod: {}
       container: {}
+
+agent:
+  ## @param wazuh.agent.enabled Enable the agent
+  enabled: false
+
+  service:
+    port: 5000
+    type: ClusterIP
+
+  ## @param wazuh.agent.labels Extra labels for the agent
+  labels: {}
+
+  ## @param wazuh.agent.annotations Extra annotations for the agent
+  annotations: {}
+
+  ## @param wazuh.agent.podAnnotations Extra annotations for the agent
+  podAnnotations: {}
+
+  ## Parameters to configure the resources allocated to the agent.
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+  ## @param wazuh.agent.resources.requests.cpu Minimum CPU assigned to the pod.
+  ## @param wazuh.agent.resources.requests.memory Minimum memory assigned to the pod.
+  ## @param wazuh.agent.resources.limits.cpu Maximum CPU used by the pod.
+  ## @param wazuh.agent.resources.limits.memory Maximum memory used by the pod.
+  ##
+  images:
+    repository: kennyopennix/wazuh-agent
+    tag: "4.11.1"
+    pullPolicy: IfNotPresent
+
+  ## Parameters to configure securityContext of the daemonSet
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ## @param wazuh.agent.securityContext Additional capabilities.
+  securityContext:
+    privileged: true
+
+  ## Parameters to configure securityContext of the pod.
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ## @param wazuh.agent.podSecurityContext Additional capabilities.
+  podSecurityContext:
+    privileged: true
+
+  ## Parameters to configure the resources allocated to the agent.
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+  ## @param wazuh.agent.resources.requests.cpu Minimum CPU assigned to the pod.
+  ## @param wazuh.agent.resources.requests.memory Minimum memory assigned to the pod.
+  ## @param wazuh.agent.resources.limits.cpu Maximum CPU used by the pod.
+  ## @param wazuh.agent.resources.limits.memory Maximum memory used by the pod.
+  ##
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
+  ## Parameters to configure the nodeSelector.
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  ## @param wazuh.agent.nodeSelector nodeSelector
+  nodeSelector: {}
+
+  ## Parameters to configure the affinity.
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  ## @param wazuh.agent.affinity
+  affinity: {}
+
+  ## Parameters to configure the tolerations.
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  ## @param wazuh.agent.tolerations
+  tolerations: []
+
+  ## Parameters to configure the join manager.
+  ## @param wazuh.agent.joinManager.scheme Join manager scheme
+  joinManager:
+    scheme: https
+    wazuh:
+      group: default
+
+  ## Parameters to configure the livenessProbe.
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  ## @param wazuh.agent.livenessProbe.periodSeconds How often to perform the probe.
+  ## @param wazuh.agent.livenessProbe.timeoutSeconds When the probe times out.
+  ## @param wazuh.agent.livenessProbe.failureThreshold Minimum failures for the probe to be considered failed after having succeeded.
+  ## @param wazuh.agent.livenessProbe.successThreshold Minimum successes for the probe to be considered successful
+  ## after having failed.
+  ## @param wazuh.agent.livenessProbe.initialDelaySeconds Delay before liveness probe is initiated.
+  livenessProbe: {}
+#    httpGet:
+#      path: /healz
+#      port: 5000
+#    initialDelaySeconds: 40
+#    periodSeconds: 10
+#    timeoutSeconds: 10
+#    failureThreshold: 5
+
+  ## Parameters to configure the volumes.
+  ## Ref: https://kubernetes.io/docs/concepts/storage/volumes/
+  ## @param wazuh.agent.volumes List of volumes
+  volumes:
+#    - name: docker-socket-mount
+#      hostPath:
+#        path: /var/run/docker.sock
+    - name: var-run
+      hostPath:
+        path: /var/run
+    - name: dev
+      hostPath:
+        path: /dev
+    - name: sys
+      hostPath:
+        path: /sys
+    - name: proc
+      hostPath:
+        path: /proc
+    - name: etc
+      hostPath:
+        path: /etc
+    - name: boot
+      hostPath:
+        path: /boot
+    - name: usr
+      hostPath:
+        path: /usr
+    - name: modules
+      hostPath:
+        path: /lib/modules
+    - name: log
+      hostPath:
+        path: /var/log
+
+  ## Parameters to configure the volume mounts.
+  ## Ref: https://kubernetes.io/docs/concepts/storage/volumes/
+  ## @param wazuh.agent.volumeMounts List of volume mounts
+  volumeMounts:
+    - mountPath: /var/run
+      name: var-run
+    - mountPath: /host/dev
+      name: dev
+    - mountPath: /host/sys
+      name: sys
+      readOnly: true
+    - mountPath: /host/proc
+      name: proc
+      readOnly: true
+    - mountPath: /host/etc
+      name: etc
+      readOnly: true
+#    - mountPath: /var/run/docker.sock
+#      name: docker-socket-mount
+#    - mountPath: /host/var/run/docker.sock
+#      name: docker-socket-mount
+    - mountPath: /host/boot
+      name: boot
+      readOnly: true
+    - mountPath: /host/usr
+      name: usr
+      readOnly: true
+    - mountPath: /host/lib/modules
+      name: modules
+      readOnly: true
+    - mountPath: /host/var/log
+      name: log
+      readOnly: true
+
+  ## Extra configuration for the agent
+  ## @param agent.extraSpec This section is less prioritized than the others
+  ## @param agent.extraSpec.daemonSet Extra configuration for the agent daemonSet
+  ## @param agent.extraSpec.pod Extra configuration for the agent pod
+  ## @param agent.extraSpec.container Extra configuration for the agent container
+  extraSpec:
+    daemonSet: {}
+    pod: {}
+    container: {}


### PR DESCRIPTION
Changelog:
1. Fixing filebeat certificates failed to verify
2. add new type: wazuh-agent. Please be aware that GKE Autopilot only support /var/log volumes, so if you are using GKE Autopilot we have to replaced the volumes and volumeMounts in the config.
<img width="1871" height="650" alt="image" src="https://github.com/user-attachments/assets/5b8682fb-d1e2-4b18-b876-1eb6f9671fdf" />