### PR TITLE
Add syslog port 514 mapping for wazuh container

### DIFF
--- a/charts/wazuh/templates/manager/worker/statefulset.yaml
+++ b/charts/wazuh/templates/manager/worker/statefulset.yaml
@@ -176,6 +176,10 @@ spec:
               name: agents-events
             - containerPort: {{ .Values.wazuh.service.port }}
               name: cluster
+            {{- if .Values.wazuh.syslog_enable }}
+            - containerPort: 514
+              name: syslog
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ .Values.indexer.cred.existingSecret | default "indexer-cred" }}


### PR DESCRIPTION
We have to add syslog port for wazuh container, because tools generated audit logs(like Falcosidekick) can not connect to remote.