### PR TITLE
Allow of setting addtitional ports for remote section of ossec.conf

### DIFF
--- a/charts/wazuh/templates/_helpers.tpl
+++ b/charts/wazuh/templates/_helpers.tpl
@@ -660,12 +660,16 @@ wazuh_clusterd.debug=0
     <log_format>plain</log_format>
   </logging>
 
-  <remote>
-    <connection>secure</connection>
-    <port>{{ .Values.wazuh.worker.service.ports.agentEvents }}</port>
-    <protocol>tcp</protocol>
-    <queue_size>131072</queue_size>
-  </remote>
+{{- range .Values.wazuh.worker.service.ports }}
+  {{- if eq .name "agents-events" }}
+    <remote>
+      <connection>secure</connection>
+      <port>{{ .port }}</port>
+      <protocol>tcp</protocol>
+      <queue_size>131072</queue_size>
+    </remote>
+  {{- end }}
+{{- end }}
 
   <!-- Policy monitoring -->
   <rootcheck>
@@ -1011,12 +1015,16 @@ wazuh_clusterd.debug=0
     <log_format>plain</log_format>
   </logging>
 
-  <remote>
-    <connection>secure</connection>
-    <port>{{ .Values.wazuh.worker.service.ports.agentEvents }}</port>
-    <protocol>tcp</protocol>
-    <queue_size>131072</queue_size>
-  </remote>
+{{- range .Values.wazuh.worker.service.ports }}
+  {{- if eq .name "agents-events" }}
+    <remote>
+      <connection>secure</connection>
+      <port>{{ .port }}</port>
+      <protocol>tcp</protocol>
+      <queue_size>131072</queue_size>
+    </remote>
+  {{- end }}
+{{- end }}
 
   <!-- Policy monitoring -->
   <rootcheck>

--- a/charts/wazuh/templates/manager/worker/networkpolicy.yaml
+++ b/charts/wazuh/templates/manager/worker/networkpolicy.yaml
@@ -14,8 +14,10 @@ spec:
     - Egress
   ingress:
     - ports:
-        - protocol: TCP
-          port: {{ .Values.wazuh.worker.service.ports.agentEvents }}
+        {{- range .Values.wazuh.worker.service.ports }}
+        - protocol: {{ .protocol | default "TCP" }}
+          port: {{ .port }}
+        {{- end }}
     {{- if .Values.wazuh.syslog_enable }}
     - ports:
         - protocol: TCP

--- a/charts/wazuh/templates/manager/worker/service.yaml
+++ b/charts/wazuh/templates/manager/worker/service.yaml
@@ -10,14 +10,17 @@ metadata:
     {{- toYaml .Values.wazuh.worker.service.annotations | nindent 4 }}
 spec:
   ports:
-    - name: agents-events
-      port: {{ .Values.wazuh.worker.service.ports.agentEvents }}
-      targetPort: {{ .Values.wazuh.worker.service.ports.agentEvents }}
-{{- if .Values.wazuh.syslog_enable }}
+  {{- range .Values.wazuh.worker.service.ports }}
+    - name: {{ .name }}
+      protocol: {{ .protocol | default "TCP" }}
+      port: {{ .port }}
+      targetPort: {{ .targetPort }}
+  {{- end }}
+  {{- if .Values.wazuh.syslog_enable }}
     - name: syslog
       port: 514
       targetPort: 514
-{{- end }}
+  {{- end }}
   selector:
     app: {{ include "wazuh.fullname" . }}-manager
     node-type: worker

--- a/charts/wazuh/templates/manager/worker/statefulset.yaml
+++ b/charts/wazuh/templates/manager/worker/statefulset.yaml
@@ -172,10 +172,10 @@ spec:
               subPath: {{ .name }}-agent.conf
             {{- end }}
           ports:
-            - containerPort: {{ .Values.wazuh.worker.service.ports.agentEvents }}
-              name: agents-events
-            - containerPort: {{ .Values.wazuh.service.port }}
-              name: cluster
+            {{- range .Values.wazuh.worker.service.ports }}
+            - containerPort: {{ .port }}
+              name: {{ .name }}
+            {{- end }}
             {{- if .Values.wazuh.syslog_enable }}
             - containerPort: 514
               name: syslog

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -709,12 +709,22 @@ wazuh:
     ## @param wazuh.worker.service.annotations Annotations of the created service.
     ## @param wazuh.worker.service.ports.agentEvents Port for the agentEvents endpoint.
     ##
+    ## You can add additional ports in ports section like this:
+    ##ports:
+    ##  - name: my-custom-remote
+    ##    protocol: TCP or UDP
+    ##    port: 1234
+    ##    targetPort: 1234
+    ## this ports will be also added to sts container ports
+
     service:
       type: ClusterIP
       annotations: {}
       ports:
-        agentEvents: 1514
-        
+        - name: agents-events
+          protocol: TCP
+          port: 1514
+          targetPort: 1514
     ## Allows to configure the pod disruption budget of the worker. Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
     ## @param wazuh.worker.pdb.enabled Enables pdb for worker.
     ## @skip wazuh.worker.pdb.maxUnavailable


### PR DESCRIPTION
In my case, i use like 20 additional ports and i define them in ossec.conf in <remote> section. I edited templates, so we can use array of ports and include them to sts pods and service. Don't know if we need to specify this ports on master pods and service too, it seems like in this chart we only use workers for workload. Also, in ossec.conf template for worker and master i only added default agents-events port in <remote>, because we can patch ossec.conf with wazuh api later.