### PR TITLE
fix: file used for checksum doesn't exist

### DIFF
--- a/charts/wazuh/templates/dashboard/deployment.yaml
+++ b/charts/wazuh/templates/dashboard/deployment.yaml
@@ -22,7 +22,8 @@ spec:
       annotations:
         {{- if .Values.autoreload.enabled }}
         checksum/configmap: {{ include (print $.Template.BasePath "/dashboard/configmap.yaml") . | sha256sum }}
-        checksum/certificate: {{ include (print $.Template.BasePath "/certs/certificate.yaml") . | sha256sum }}
+        checksum/dashboard-certificate: {{ include (print $.Template.BasePath "/certs/dashboard/certificate.yaml") . | sha256sum }}
+        checksum/admin-certificate: {{ include (print $.Template.BasePath "/certs/admin/certificate.yaml") . | sha256sum }}
         checksum/dashboard-secret: {{ include (print $.Template.BasePath "/dashboard/secret.yaml") . | sha256sum }}
         checksum/indexer-secret: {{ include (print $.Template.BasePath "/indexer/secret.yaml") . | sha256sum }}
         checksum/api-secret: {{ include (print $.Template.BasePath "/manager/secret-api-cred.yaml") . | sha256sum }}

--- a/charts/wazuh/templates/indexer/statefulset.yaml
+++ b/charts/wazuh/templates/indexer/statefulset.yaml
@@ -26,7 +26,8 @@ spec:
       annotations:
         {{- if .Values.autoreload.enabled }}
         checksum/configmap: {{ include (print $.Template.BasePath "/indexer/configmap.yaml") . | sha256sum }}
-        checksum/certificate: {{ include (print $.Template.BasePath "/certs/certificate.yaml") . | sha256sum }}
+        checksum/admin-certificate: {{ include (print $.Template.BasePath "/certs/admin/certificate.yaml") . | sha256sum }}
+        checksum/node-certificate: {{ include (print $.Template.BasePath "/certs/node/certificate.yaml") . | sha256sum }}
         {{- end }}
         {{- with .Values.indexer.annotations }}
             {{- toYaml . | nindent 8 }}

--- a/charts/wazuh/templates/manager/master/statefulset.yaml
+++ b/charts/wazuh/templates/manager/master/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         {{- if .Values.autoreload.enabled }}
         checksum/configmap: {{ include (print $.Template.BasePath "/manager/configmap.yaml") . | sha256sum }}
-        checksum/certificate: {{ include (print $.Template.BasePath "/certs/certificate.yaml") . | sha256sum }}
+        checksum/filebeat-certificate: {{ include (print $.Template.BasePath "/certs/filebeat/certificate.yaml") . | sha256sum }}
         checksum/indexer-secret: {{ include (print $.Template.BasePath "/indexer/secret.yaml") . | sha256sum }}
         checksum/api-secret: {{ include (print $.Template.BasePath "/manager/secret-api-cred.yaml") . | sha256sum }}
         {{- end }}

--- a/charts/wazuh/templates/manager/worker/statefulset.yaml
+++ b/charts/wazuh/templates/manager/worker/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         {{- if .Values.autoreload.enabled }}
         checksum/configmap: {{ include (print $.Template.BasePath "/manager/configmap.yaml") . | sha256sum }}
-        checksum/certificate: {{ include (print $.Template.BasePath "/certs/certificate.yaml") . | sha256sum }}
+        checksum/filebeat-certificate: {{ include (print $.Template.BasePath "/certs/filebeat/certificate.yaml") . | sha256sum }}
         checksum/indexer-secret: {{ include (print $.Template.BasePath "/indexer/secret.yaml") . | sha256sum }}
         {{- end }}
         {{- with .Values.wazuh.worker.annotations }}
@@ -185,7 +185,7 @@ spec:
             # Agent groups configuration
             {{- range .Values.wazuh.agentGroupConf }}
             - name: config
-              mountPath: /wazuh-config-mount/etc/shared/{{.name}}/agent.conf
+              mountPath: /wazuh-config-mount/etc/shared/{{ .name }}/agent.conf
               subPath: {{ .name }}-agent.conf
             {{- end }}
           ports:


### PR DESCRIPTION
### Fixed
- Updated checksum annotation to reference the correct config file, preventing Helm from failing when the previous file path did not exist.