### PR TITLE
Fix agent service annotations in service.yaml 

### DIFF
--- a/charts/wazuh/templates/agent/service.yaml
+++ b/charts/wazuh/templates/agent/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ include "wazuh.fullname" . }}-agent
     node-type: agent
   annotations:
-    {{- toYaml .Values.wazuh.master.service.annotations | nindent 4 }}
+    {{- toYaml .Values.agent.service.annotations | nindent 4 }}
 spec:
   ports:
     - name: http

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -841,6 +841,7 @@ agent:
   service:
     port: 5000
     type: ClusterIP
+    annotations: {}
 
   ## @param wazuh.agent.labels Extra labels for the agent
   labels: {}


### PR DESCRIPTION
Updates the agent service template to use it's own annotations `agent.service.annotations` rather than the Wazuh master service annotations `wazuh.master.service.annotations` which was requiring the `agent.service.type` to be set as `LoadBalancer` unnecessarily when applying annotations to the master service.

Not exactly clear if the agent actually needs to have a service, but this keeps it from being tied to the master service which it definitely doesn't need to be.

Closes: morgoved/wazuh-helm#47