### PR TITLE
fixing interpretation of externalIndexer.enabled value

### DIFF
--- a/charts/wazuh/templates/_helpers.tpl
+++ b/charts/wazuh/templates/_helpers.tpl
@@ -1105,7 +1105,7 @@ wazuh_clusterd.debug=0
     {{- if .Values.indexer.enabled }}
       <host>https://{{ include "wazuh.indexer.fullname" . }}-indexer:{{ .Values.indexer.service.httpPort }}</host>
     {{- end }}
-    {{- if not .Values.externalIndexer.enabled }}
+    {{- if .Values.externalIndexer.enabled }}
       <host>https://{{ .Values.externalIndexer.host }}:{{ .Values.externalIndexer.port }}</host>
     {{- end }}
     </hosts>


### PR DESCRIPTION
The externalIndexer.enabled value was mininterpreted in the manager-worker config.