### PR TITLE
feat: Add wazuh.loadBalancer value for external agent and api usage

### DIFF
--- a/charts/wazuh/templates/manager/load-balancer.yaml
+++ b/charts/wazuh/templates/manager/load-balancer.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.wazuh.loadBalancer.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wazuh.fullname" . }}-manager-lb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "wazuh.fullname" . }}-manager
+  annotations:
+    {{- with .Values.wazuh.loadBalancer.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: LoadBalancer
+  ports:
+  {{- range .Values.wazuh.master.service.ports }}
+    - name: {{ .name }}
+      protocol: {{ .protocol | default "TCP" }}
+      port: {{ .port }}
+      targetPort: {{ .targetPort }}
+  {{- end }}
+  {{- range .Values.wazuh.worker.service.ports }}
+    - name: {{ .name }}
+      protocol: {{ .protocol | default "TCP" }}
+      port: {{ .port }}
+      targetPort: {{ .targetPort }}
+  {{- end }}
+  {{- if .Values.wazuh.syslog_enable }}
+    - name: syslog
+      port: 514
+      targetPort: 514
+      protocol: UDP
+  {{- end }}
+  selector:
+    app: {{ include "wazuh.fullname" . }}-manager
+{{- end -}}

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -551,7 +551,7 @@ wazuh:
   ## @param wazuh.loadBalancer.annotations Annotations for LoadBalancer service (e.g., AWS NLB annotations)
   ##
   loadBalancer:
-    enabled: true
+    enabled: false
     annotations: {}
       ## Example AWS NLB annotations:
       # service.beta.kubernetes.io/aws-load-balancer-type: "external"

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -546,6 +546,18 @@ wazuh:
   key: "c98b62a9b6169ac5f67dae55ae4a9088"
   ## Parameters for the image of the manager.
   ##
+  ## LoadBalancer service for external agent, api access via NLB
+  ## @param wazuh.loadBalancer.enabled Enable LoadBalancer service for external agent connections
+  ## @param wazuh.loadBalancer.annotations Annotations for LoadBalancer service (e.g., AWS NLB annotations)
+  ##
+  loadBalancer:
+    enabled: true
+    annotations: {}
+      ## Example AWS NLB annotations:
+      # service.beta.kubernetes.io/aws-load-balancer-type: "external"
+      # service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+      # service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+      # service.beta.kubernetes.io/aws-load-balancer-subnets: "subnet-xxx,subnet-yyy"
   images:
     ## @param wazuh.images.repository name of the image used. If you use your own image registry
     ## just enter the url for the image. E.g.: my.registry.de/registry/wazuh/wazuh-manager


### PR DESCRIPTION
# Add LoadBalancer Service for External Agent and API Access

## Summary

This PR adds support for a dedicated LoadBalancer service to enable external Wazuh agents and API access through cloud load balancers like AWS NLB. https://github.com/morgoved/wazuh-helm/issues/55

## Changes

- **New Template**: Added `charts/wazuh/templates/manager/load-balancer.yaml` 
  - Creates a LoadBalancer service when `wazuh.loadBalancer.enabled` is true
  - Exposes master and worker service ports
  - Includes syslog port (514/UDP) when syslog is enabled
  - Supports custom annotations for cloud provider configuration

- **Configuration**: Updated `charts/wazuh/values.yaml`
  - Added `wazuh.loadBalancer` configuration section
  - Enabled by default (`enabled: true`)
  - Includes example AWS NLB annotations for reference

## Features

- Configurable LoadBalancer service for external access
- Supports cloud provider annotations (AWS NLB, GCP, etc.)
- Automatic port mapping from existing master/worker services  
- Optional syslog UDP port exposure
- Can be disabled via `wazuh.loadBalancer.enabled: false`

## Use Cases

- External Wazuh agents connecting from outside the Kubernetes cluster
- API access through cloud load balancers
- Production deployments requiring external connectivity
- Multi-region Wazuh agent deployments

## Configuration Example

```yaml
wazuh:
  loadBalancer:
    enabled: true
    annotations:
      service.beta.kubernetes.io/aws-load-balancer-type: "external"
      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
      service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
```
