### PR TITLE
Add serviceaccount support and don't create wazuh-agent if disabled

### DIFF
--- a/charts/wazuh/templates/_helpers.tpl
+++ b/charts/wazuh/templates/_helpers.tpl
@@ -2290,3 +2290,30 @@ Get port value from ports array by name
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Define serviceaccount names
+*/}}
+{{- define "wazuh.indexer.serviceAccountName" -}}
+{{- if .Values.indexer.serviceAccount.create -}}
+    {{ default (printf "%s-indexer" (include "wazuh.indexer.fullname" .)) .Values.indexer.serviceAccount.name }}
+{{- else -}}
+    {{ "default" }}
+{{- end -}}
+{{- end -}}
+
+{{- define "wazuh.dashboard.serviceAccountName" -}}
+{{- if .Values.dashboard.serviceAccount.create -}}
+    {{ default (printf "%s-dashboard" (include "wazuh.fullname" .)) .Values.dashboard.serviceAccount.name }}
+{{- else -}}
+    {{ "default" }}
+{{- end -}}
+{{- end -}}
+
+{{- define "wazuh.manager.serviceAccountName" -}}
+{{- if .Values.wazuh.serviceAccount.create -}}
+    {{ default (printf "%s-manager" (include "wazuh.fullname" .)) .Values.wazuh.serviceAccount.name }}
+{{- else -}}
+    {{ "default" }}
+{{- end -}}
+{{- end -}}

--- a/charts/wazuh/templates/agent/daemonset.yaml
+++ b/charts/wazuh/templates/agent/daemonset.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  serviceAccountName: {{ include "wazuh.agent.serviceAccountName" . }}
   {{- with .Values.agent.extraSpec.daemonSet }}
   {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/charts/wazuh/templates/agent/service.yaml
+++ b/charts/wazuh/templates/agent/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.agent.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
     app: {{ include "wazuh.fullname" . }}-agent
     node-type: agent
   type: {{ .Values.agent.service.type }}
+{{- end }}

--- a/charts/wazuh/templates/dashboard/deployment.yaml
+++ b/charts/wazuh/templates/dashboard/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     {{- toYaml .Values.dashboard.annotations | nindent 4 }}
 spec:
+  serviceAccountName: {{ include "wazuh.dashboard.serviceAccountName" . }}
   {{- with .Values.dashboard.extraSpec.deployment }}
   {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/charts/wazuh/templates/indexer/statefulset.yaml
+++ b/charts/wazuh/templates/indexer/statefulset.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     {{- toYaml .Values.indexer.annotations | nindent 4 }}
 spec:
+  serviceAccountName: {{ include "wazuh.indexer.serviceAccountName" . }}
   {{- with .Values.indexer.extraSpec.statefulSet }}
   {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/charts/wazuh/templates/manager/master/statefulset.yaml
+++ b/charts/wazuh/templates/manager/master/statefulset.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     {{- toYaml .Values.wazuh.master.annotations | nindent 4 }}
 spec:
+  serviceAccountName: {{ include "wazuh.manager.serviceAccountName" . }}
   {{- with .Values.wazuh.master.extraSpec.statefulSet }}
   {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/charts/wazuh/templates/manager/worker/statefulset.yaml
+++ b/charts/wazuh/templates/manager/worker/statefulset.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     {{- toYaml .Values.wazuh.worker.annotations | nindent 4 }}
 spec:
+  serviceAccountName: {{ include "wazuh.manager.serviceAccountName" . }}
   {{- with .Values.wazuh.worker.extraSpec.statefulSet }}
   {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -63,6 +63,12 @@ externalIndexer:
 indexer:
   ## @param indexer.enabled defines if we deploy indexer or not 
   enabled: true
+
+  ## @param indexer.serviceAccount defines wazuh indexer serviceAccount
+  serviceAccount:
+    create: false
+    annotations: {}
+    name: "wazuh-indexer"
   ## @param indexer.replicas number of replicas used in statefulset.
   ##
   replicas: 3
@@ -262,6 +268,11 @@ indexer:
 ## pre-installed
 ##
 dashboard:
+  ## @param dashboard.serviceAccount defines wazuh dashboard serviceAccount
+  serviceAccount:
+    create: false
+    annotations: {}
+    name: "wazuh-dashboard"
   ## @param dashboard.replicas number of replicas used in deployment.
   ##
   replicas: 1
@@ -538,6 +549,11 @@ dashboard:
 ## @section wazuh configuration of the wazuh core component.
 ##
 wazuh:
+  ## @param wazuh.serviceAccount defines wazuh manager serviceAccount
+  serviceAccount:
+    create: false
+    annotations: {}
+    name: "wazuh-manager"
   ## @param wazuh.syslog_enable Enables the syslog of the wazuh instance.
   ##
   syslog_enable: true
@@ -876,6 +892,12 @@ wazuh:
 agent:
   ## @param wazuh.agent.enabled Enable the agent
   enabled: false
+
+  ## @param agent.serviceAccount defines wazuh agent serviceAccount
+  serviceAccount:
+    create: false
+    annotations: {}
+    name: "wazuh-agent"
 
   service:
     port: 5000


### PR DESCRIPTION
Fixes https://github.com/morgoved/wazuh-helm/issues/58 and https://github.com/morgoved/wazuh-helm/issues/59


I've tried to keep backwards compatibility by defaulting to "default" serviceAccountName