### PR TITLE
Update Wazuh HELM chart to version 4.12.0

### DIFF
--- a/charts/wazuh/Chart.yaml
+++ b/charts/wazuh/Chart.yaml
@@ -8,12 +8,16 @@ annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/category: security
   artifacthub.io/changes: |
+    - kind: changed
+      description: "Update all components to Wazuh 4.12.0"
+    - kind: changed
+      description: "Update agent image to 4.12.0"
+    - kind: added
+      description: "Add ARM architecture support via nodeSelector"
     - kind: added
       description: "Add support for cert-manager"
     - kind: changed
       description: "Refactor whole chart"
-    - kind: changed
-      description: "Bump wazuh-manager to 4.10.1"
   artifacthub.io/links: |
     - name: application source
       url: https://github.com/wazuh/wazuh

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -900,7 +900,7 @@ agent:
   ##
   images:
     repository: opennix/wazuh-agent
-    tag: "4.11.1"
+    tag: "4.12.0"
     pullPolicy: IfNotPresent
 
   ## Parameters to configure securityContext of the daemonSet


### PR DESCRIPTION
- Update agent image from 4.11.1 to 4.12.0 for version consistency
- Fix Chart.yaml changelog to reflect current 4.12.0 updates
- Ensure all components (manager, indexer, dashboard, agent) use 4.12.0
- Maintain ARM architecture support via existing nodeSelector configs