### PR TITLE
fix: add missing ServiceAccount templates and helper function

### DIFF
--- a/charts/wazuh/templates/_helpers.tpl
+++ b/charts/wazuh/templates/_helpers.tpl
@@ -2317,3 +2317,11 @@ Define serviceaccount names
     {{ "default" }}
 {{- end -}}
 {{- end -}}
+
+{{- define "wazuh.agent.serviceAccountName" -}}
+{{- if .Values.agent.serviceAccount.create -}}
+    {{ default (printf "%s-agent" (include "wazuh.fullname" .)) .Values.agent.serviceAccount.name }}
+{{- else -}}
+    {{ "default" }}
+{{- end -}}
+{{- end -}}

--- a/charts/wazuh/templates/agent/serviceaccount.yaml
+++ b/charts/wazuh/templates/agent/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.agent.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wazuh.agent.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "wazuh.fullname" . }}-agent
+    app.kubernetes.io/component: agent
+  {{- with .Values.agent.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.agent.serviceAccount.automountServiceAccountToken | default true }}
+{{- end }}

--- a/charts/wazuh/templates/dashboard/serviceaccount.yaml
+++ b/charts/wazuh/templates/dashboard/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.dashboard.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wazuh.dashboard.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "wazuh.fullname" . }}-dashboard
+    app.kubernetes.io/component: dashboard
+  {{- with .Values.dashboard.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.dashboard.serviceAccount.automountServiceAccountToken | default true }}
+{{- end }}

--- a/charts/wazuh/templates/indexer/serviceaccount.yaml
+++ b/charts/wazuh/templates/indexer/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.indexer.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wazuh.indexer.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "wazuh.indexer.fullname" . }}-indexer
+    app.kubernetes.io/component: indexer
+  {{- with .Values.indexer.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.indexer.serviceAccount.automountServiceAccountToken | default true }}
+{{- end }}

--- a/charts/wazuh/templates/manager/serviceaccount.yaml
+++ b/charts/wazuh/templates/manager/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.wazuh.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wazuh.manager.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "wazuh.fullname" . }}-manager
+    app.kubernetes.io/component: manager
+  {{- with .Values.wazuh.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.wazuh.serviceAccount.automountServiceAccountToken | default true }}
+{{- end }}


### PR DESCRIPTION
The Wazuh Helm chart was missing ServiceAccount templates for all components (indexer, dashboard, manager, agent) and the wazuh.agent.serviceAccountName helper function, causing:

1. No ServiceAccount resources to be created when serviceAccount.create=true
2. Template rendering to fail when agent.enabled=true due to missing helper

This fix adds:
- ServiceAccount templates for all 4 components (indexer, dashboard, manager, agent)
- Missing wazuh.agent.serviceAccountName helper function in _helpers.tpl

Now ServiceAccounts are properly created with annotations (e.g., for AWS IAM roles) and pods use the correct ServiceAccount instead of 'default'.

Fixes template rendering error:
'template: no template "wazuh.agent.serviceAccountName" associated with template "gotpl"'
