### PR TITLE
Support additional volumes in indexer

### DIFF
--- a/charts/wazuh/templates/dashboard/networkpolicy.yaml
+++ b/charts/wazuh/templates/dashboard/networkpolicy.yaml
@@ -31,10 +31,10 @@ spec:
     - ports:
       - protocol: TCP
     {{- range .Values.wazuh.master.service.ports }}
-      {{ if eq .name "api" }}
+      {{- if eq .name "api" }}
         port: {{ .port }}
-      {{ end }}
-    {{ end }}
+      {{- end }}
+    {{- end }}
       to:
         - podSelector:
             matchLabels:

--- a/charts/wazuh/templates/indexer/configmap.yaml
+++ b/charts/wazuh/templates/indexer/configmap.yaml
@@ -19,4 +19,8 @@ data:
     {{- tpl .Values.indexer.config.roles . | nindent 4 }}
   config.yml: |
     {{- tpl .Values.indexer.config.securityConfig . | nindent 4 }}
+{{- range $configName, $configYaml := .Values.indexer.additionalConfigs }}
+  {{ $configName }}: |
+    {{-   tpl $configYaml . | nindent 4 }}
+{{- end -}}
 {{- end }}

--- a/charts/wazuh/templates/indexer/statefulset.yaml
+++ b/charts/wazuh/templates/indexer/statefulset.yaml
@@ -90,6 +90,9 @@ spec:
       - configMap:
           name: {{ include "wazuh.indexer.fullname" . }}-indexer-config
         name: indexer-conf
+      {{- with .Values.indexer.additionalVolumes }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
       containers:
         - name: wazuh-indexer
           {{- with .Values.indexer.extraSpec.container }}
@@ -192,6 +195,9 @@ spec:
               mountPath: /usr/share/wazuh-indexer/opensearch-security/config.yml
               subPath: config.yml
               readOnly: true
+            {{- with .Values.indexer.additionalVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - containerPort: {{ .Values.indexer.service.httpPort }}
               name: indexer-rest

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -213,6 +213,14 @@ indexer:
   ## Ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
   ##
   additionalEnv: []
+  ## @param indexer.additionalVolumes Possibility to define additional volumes in the pod.
+  ## Ref: https://kubernetes.io/docs/concepts/storage/volumes/
+  ##
+  additionalVolumes: []
+  ## @param indexer.additionalVolumeMounts Possibility to define additional volumeMounts in the pod.
+  ## Ref: https://kubernetes.io/docs/concepts/storage/volumes/
+  ##
+  additionalVolumeMounts: []
   ## Configuration of the indexer parameters, this should not be changed.
   ## @param indexer.config.opensearch Configuration of opensearch.yml.
   ## @param indexer.config.internalUsers Configuration of internalUsers of the indexer.
@@ -231,6 +239,8 @@ indexer:
       {{ include "wazuh.indexer.rolesMapping" . }}
     roles: |-
       {{ include "wazuh.indexer.roles" . }}
+  ## Additional configurations to add to the configmap
+  additionalConfigs: {}
   ## Parameters for the sysctlImage initContainer.
   ##
   sysctlImage:


### PR DESCRIPTION
We had to to add our internal CA to the indexer configuration, this PR adds support for addtionalConfigs, additionalVolumes and additionalVolumeMounts to the indexer.

The PR also removes whitespaces from the dashboards networkpolicy


We're currently running this in production and it's working as expected. But please verify

