### PR TITLE
fix: Fix agent group configuration synchronization by correcting ConfigMap mount permissions

### DIFF
--- a/charts/wazuh/templates/manager/master/statefulset.yaml
+++ b/charts/wazuh/templates/manager/master/statefulset.yaml
@@ -124,6 +124,20 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - |
+                  {{- range .Values.wazuh.agentGroupConf }}
+                  if [ -d "/var/ossec/etc/shared/{{ .name }}" ]; then
+                    chown -R wazuh:wazuh /var/ossec/etc/shared/{{ .name }}
+                    chmod 770 /var/ossec/etc/shared/{{ .name }}
+                    chmod 660 /var/ossec/etc/shared/{{ .name }}/* 2>/dev/null || true
+                  fi
+                  {{- end }}
           volumeMounts:
             # Wazuh Config
             - mountPath: /wazuh-config-mount/etc/

--- a/charts/wazuh/templates/manager/worker/statefulset.yaml
+++ b/charts/wazuh/templates/manager/worker/statefulset.yaml
@@ -139,6 +139,20 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - |
+                  {{- range .Values.wazuh.agentGroupConf }}
+                  if [ -d "/var/ossec/etc/shared/{{ .name }}" ]; then
+                    chown -R wazuh:wazuh /var/ossec/etc/shared/{{ .name }}
+                    chmod 770 /var/ossec/etc/shared/{{ .name }}
+                    chmod 660 /var/ossec/etc/shared/{{ .name }}/* 2>/dev/null || true
+                  fi
+                  {{- end }}
           volumeMounts:
             # Wazuh config
             - mountPath: /wazuh-config-mount/etc/


### PR DESCRIPTION
# Fix agent group configuration synchronization by correcting ConfigMap mount permissions

## Problem

Agent group configurations mounted via ConfigMaps create directories with `root:root` ownership and `755` permissions, preventing the Wazuh manager process (running as `wazuh` user) from generating the required `merged.mg` files. This causes agents to receive the `default` group configuration instead of their assigned group configuration.

### Root Cause

1. ConfigMaps always mount with `root:root` ownership
2. Agent group directories like `some_agent_group` are created with incorrect permissions: `drwxr-xr-x root:root`
3. The `wazuh` user cannot write to these directories to create `merged.mg` files
4. Without `merged.mg` files, agents cannot synchronize with their assigned group configuration
5. Agents fall back to receiving the `default` group configuration

### Symptom

```bash
/var/ossec/bin/agent_groups -S -i 052
# Returns: Agent '052' is not synchronized.
```

The agent is assigned to the correct group but cannot receive the group-specific configuration.

## Solution

Add **postStart lifecycle hooks** to both master and worker containers that fix the ownership and permissions of agent group directories after all ConfigMaps are mounted.

### Technical Details

The fix ensures agent group directories have the same permissions as the working `default` group:
- **Directory permissions**: `drwxrwx---` (770) - `wazuh:wazuh`
- **File permissions**: `rw-rw----` (660) - `wazuh:wazuh`

This allows the Wazuh manager to:
1. Create `merged.mg` files in group directories
2. Update group configurations when needed
3. Properly synchronize agent group assignments

## Changes

### Modified Files

1. `templates/manager/master/statefulset.yaml` - Added postStart lifecycle hook
2. `templates/manager/worker/statefulset.yaml` - Added postStart lifecycle hook

### Added Lifecycle Hook

```yaml
lifecycle:
  postStart:
    exec:
      command:
      - /bin/sh
      - -c
      - |
        {{- range .Values.wazuh.agentGroupConf }}
        if [ -d "/var/ossec/etc/shared/{{ .name }}" ]; then
          chown -R wazuh:wazuh /var/ossec/etc/shared/{{ .name }}
          chmod 770 /var/ossec/etc/shared/{{ .name }}
          chmod 660 /var/ossec/etc/shared/{{ .name }}/* 2>/dev/null || true
        fi
        {{- end }}
```

## Testing

### Before Fix
```bash
kubectl exec wazuh-manager-master-0 -n wazuh -- ls -la /var/ossec/etc/shared/
# some_agent_group: drwxr-xr-x root root (no merged.mg file)
# default:          drwxrwx--- wazuh wazuh (has merged.mg file)

kubectl exec wazuh-manager-master-0 -n wazuh -- /var/ossec/bin/agent_groups -S -i 052
# Agent '052' is not synchronized.
```

### After Fix
```bash
kubectl exec wazuh-manager-master-0 -n wazuh -- ls -la /var/ossec/etc/shared/
# some_agent_group: drwxrwx--- wazuh wazuh (merged.mg file present)
# default:          drwxrwx--- wazuh wazuh (merged.mg file present)

kubectl exec wazuh-manager-master-0 -n wazuh -- /var/ossec/bin/agent_groups -S -i 052
# Agent '052' is synchronized.
```

## Impact

### Positive Impact
- ✅ Fixes agent group configuration synchronization
- ✅ Enables proper `merged.mg` file generation
- ✅ Maintains ConfigMap-based group configuration management
- ✅ No breaking changes to existing functionality
- ✅ Minimal performance impact (runs once at container startup)

### Risk Assessment
- **Low Risk**: Only affects file permissions, no functional logic changes
- **Backwards Compatible**: Works with existing configurations
- **Secure**: Maintains Wazuh security model with `wazuh:wazuh` ownership

## Alternative Solutions Considered

1. **Init Container Fix**: Rejected - ConfigMap mounts happen after init containers
2. **SecurityContext**: Rejected - Kubernetes doesn't support setting ConfigMap mount ownership
3. **Manual Permission Fix**: Rejected - Not scalable, requires manual intervention


## Related Issues

This fix resolves scenarios where:
- Agents receive default configuration despite being assigned to specific groups
- `agent_groups -S` shows agents as "not synchronized"
- Custom agent group configurations are not applied to agents
- `merged.mg` files are missing from custom group directories
