### PR TITLE
added namespace for certs

### DIFF
--- a/charts/wazuh/templates/certs/dashboard/certificate.yaml
+++ b/charts/wazuh/templates/certs/dashboard/certificate.yaml
@@ -2,6 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "wazuh.fullname" . }}-dashboard
+  namespace: {{ .Release.Namespace }}
 spec:
   # Secret names are always required.
   secretName: dashboard-tls

--- a/charts/wazuh/templates/certs/filebeat/certificate.yaml
+++ b/charts/wazuh/templates/certs/filebeat/certificate.yaml
@@ -2,6 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "wazuh.fullname" . }}-filebeat
+  namespace: {{ .Release.Namespace }}
 spec:
   # Secret names are always required.
   secretName: filebeat-tls

--- a/charts/wazuh/templates/certs/node/certificate.yaml
+++ b/charts/wazuh/templates/certs/node/certificate.yaml
@@ -2,6 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "wazuh.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
 spec:
   # Secret names are always required.
   secretName: node-tls

--- a/charts/wazuh/templates/certs/root/rootca.yaml
+++ b/charts/wazuh/templates/certs/root/rootca.yaml
@@ -2,6 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "wazuh.fullname" . }}-root-ca
+  namespace: {{ .Release.Namespace }}  
 spec:
   isCA: true
   secretName: {{ include "wazuh.fullname" . }}-root-secret


### PR DESCRIPTION
Cert created on default namespace when it deployed using CI/CD . To fix name space issue I added namespace argument for certs

That Issuerwazuh-ca-issuer) in default namespace
the chart was configured to create a namespaced Issuer (issuer.type: Issuer, issuer.name: null), and/or
the release (or kubectl context) targeted the default namespace.

**Result:** the chart created Issuer/wazuh-ca-issuer in default, and any Certificates it templated there created admin-tls, node-tls, filebeat-tls in default. Your current deployment in wazuh then can’t see those secrets, so mounts fail.