### PR TITLE
ca-issuer-namespace

### DIFF
--- a/charts/wazuh/templates/certs/root/ca-issuer.yaml
+++ b/charts/wazuh/templates/certs/root/ca-issuer.yaml
@@ -2,6 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "wazuh.fullname" . }}-ca-issuer
+  namespace: {{ .Release.Namespace }}
 spec:
   ca:
     secretName: {{ include "wazuh.fullname" . }}-root-secret


### PR DESCRIPTION
@morgoved Adding namespace to CA issuer configuration. without namespace issue created in default namespace causing failure