### PR TITLE
Fix issue-111: After the job triggers and regenerates the credentials and uploads them to the security plugin index, all credentials are reset to their default values

### DIFF
--- a/charts/wazuh/templates/agent/daemonset.yaml
+++ b/charts/wazuh/templates/agent/daemonset.yaml
@@ -129,9 +129,6 @@ spec:
           {{- with .Values.agent.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}
-            {{- with $.Values.agent.extraVolumeMounts }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
             - name: local-internal-options
               mountPath: /tmp/local_internal_options.conf
               subPath: local_internal_options.conf
@@ -149,9 +146,6 @@ spec:
       {{- with .Values.agent.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}
-        {{- with $.Values.agent.extraVolumes }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
         - name: local-internal-options
           configMap:
             name: {{ $indexerFullname }}-agent-local-internal-options


### PR DESCRIPTION
Fixing: https://github.com/morgoved/wazuh-helm/issues/111