### PR TITLE
Feature/cluster key secret

### DIFF
--- a/charts/wazuh/templates/_helpers.tpl
+++ b/charts/wazuh/templates/_helpers.tpl
@@ -1010,9 +1010,9 @@ wazuh_clusterd.debug=0
 
   <cluster>
     <name>wazuh</name>
-    <node_name>{{ include "wazuh.fullname" . }}-manager-master-0</node_name>
+    <node_name>to_be_replaced_by_hostname</node_name>
     <node_type>master</node_type>
-    <key>{{ .Values.wazuh.key }}</key>
+    <key>to_be_replaced_by_cluster_key</key>
     <port>{{ .Values.wazuh.service.port }}</port>
     <bind_addr>0.0.0.0</bind_addr>
     <nodes>
@@ -1369,9 +1369,9 @@ wazuh_clusterd.debug=0
 
   <cluster>
     <name>wazuh</name>
-    <node_name>{{ include "wazuh.fullname" . }}-manager-worker-___INDEX___</node_name>
+    <node_name>to_be_replaced_by_hostname</node_name>
     <node_type>worker</node_type>
-    <key>{{ .Values.wazuh.key }}</key>
+    <key>to_be_replaced_by_cluster_key</key>
     <port>{{ .Values.wazuh.service.port }}</port>
     <bind_addr>0.0.0.0</bind_addr>
     <nodes>

--- a/charts/wazuh/templates/manager/master/statefulset.yaml
+++ b/charts/wazuh/templates/manager/master/statefulset.yaml
@@ -252,7 +252,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: key
-                  name: "wazuh-cluster-key"
+                  name: {{ .Values.wazuh.keyExistingSecret | default "wazuh-cluster-key" }}
           {{- with .Values.wazuh.master.additionalEnv }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/wazuh/templates/manager/secret-cluster-key.yaml
+++ b/charts/wazuh/templates/manager/secret-cluster-key.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.wazuh.enabled }}
+  {{- if not .Values.wazuh.keyExistingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,4 +7,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   key: {{ .Values.wazuh.key | b64enc }}
+  {{- end }}
 {{- end }}

--- a/charts/wazuh/templates/manager/worker/statefulset.yaml
+++ b/charts/wazuh/templates/manager/worker/statefulset.yaml
@@ -242,7 +242,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: key
-                  name: "wazuh-cluster-key"
+                  name: {{ .Values.wazuh.keyExistingSecret | default "wazuh-cluster-key" }}
             # Certs
             - name: SSL_CERTIFICATE_AUTHORITIES
               value: /etc/ssl/root-ca.pem

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -649,8 +649,11 @@ wazuh:
   ##
   syslog_enable: true
   ## @param wazuh.key Defines the key of the wazuh cluster.
+  ## @param wazuh.keyExistingSecret Name of existing secret containing the cluster key. Expected key is 'key'.
+  ## If set, wazuh.key is ignored and the secret is used instead.
   ##
   key: "c98b62a9b6169ac5f67dae55ae4a9088"
+  keyExistingSecret: ""
   ## Parameters for the image of the manager.
   ## @param wazuh.images.repository name of the image used. If you use your own image registry just enter the url for the image. E.g.: my.registry.de/registry/wazuh/wazuh-manager
   ## @param wazuh.images.tag Tag of the image.


### PR DESCRIPTION
This is a further step to remove secrets from the chart values.

For the cluster key, I found that this can be done by using an existing "to_be_replaced_by_cluster_key" placeholder which the manager init files replace.
https://github.com/wazuh/wazuh-docker/blob/c893d86b4a3dff604832cbe1e9b1c760edcb4b59/build-docker-images/wazuh-manager/config/etc/cont-init.d/0-wazuh-init#L161

See issue #80
