### PR TITLE
add support for extraPodLabels

### DIFF
--- a/charts/wazuh/templates/agent/daemonset.yaml
+++ b/charts/wazuh/templates/agent/daemonset.yaml
@@ -30,6 +30,9 @@ spec:
       labels:
         app: {{ include "wazuh.indexer.fullname" . }}-agent
         node-type: agent
+        {{- with .Values.agent.extraPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "wazuh.agent.serviceAccountName" . }}
       {{- with .Values.agent.extraSpec.pod }}

--- a/charts/wazuh/templates/dashboard/deployment.yaml
+++ b/charts/wazuh/templates/dashboard/deployment.yaml
@@ -20,6 +20,9 @@ spec:
     metadata:
       labels:
         app: {{ include "wazuh.fullname" . }}-dashboard
+        {{- with .Values.dashboard.extraPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- if .Values.autoreload.enabled }}
         checksum/configmap: {{ include (print $.Template.BasePath "/dashboard/configmap.yaml") . | sha256sum }}

--- a/charts/wazuh/templates/indexer/statefulset.yaml
+++ b/charts/wazuh/templates/indexer/statefulset.yaml
@@ -23,6 +23,9 @@ spec:
     metadata:
       labels:
         app: {{ include "wazuh.indexer.fullname" . }}-indexer
+        {{- with .Values.indexer.extraPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- if .Values.autoreload.enabled }}
         checksum/configmap: {{ include (print $.Template.BasePath "/indexer/configmap.yaml") . | sha256sum }}

--- a/charts/wazuh/templates/manager/master/statefulset.yaml
+++ b/charts/wazuh/templates/manager/master/statefulset.yaml
@@ -27,6 +27,9 @@ spec:
       labels:
         app: {{ include "wazuh.fullname" . }}-manager
         node-type: master
+        {{- with .Values.wazuh.master.extraPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       name: wazuh-manager-master
       annotations:
         {{- if .Values.autoreload.enabled }}

--- a/charts/wazuh/templates/manager/worker/statefulset.yaml
+++ b/charts/wazuh/templates/manager/worker/statefulset.yaml
@@ -25,6 +25,9 @@ spec:
       labels:
         app: {{ include "wazuh.fullname" . }}-manager
         node-type: worker
+        {{- with .Values.wazuh.worker.extraPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       name: wazuh-manager-worker
       annotations:
         {{- if .Values.autoreload.enabled }}

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -77,6 +77,9 @@ indexer:
   ## @param indexer.annotations additional annotations set on statefulset.
   ##
   annotations: {}
+  ## @param indexer.extraPodLabels Extra labels to add to the indexer pods.
+  ##
+  extraPodLabels: {}
   ## @param indexer.updateStrategy updateStrategy for the statefulset.
   ##
   updateStrategy: RollingUpdate
@@ -323,6 +326,9 @@ dashboard:
   ## @param dashboard.annotations additional annotations set on deployment.
   ##
   annotations: {}
+  ## @param dashboard.extraPodLabels Extra labels to add to the dashboard pods.
+  ##
+  extraPodLabels: {}
   ## Parameters for the image of the dashboard.
   ##
   images:
@@ -764,6 +770,9 @@ wazuh:
     ## @param wazuh.master.annotations additional annotations set on statefulset.
     ##
     annotations: {}
+    ## @param wazuh.master.extraPodLabels Extra labels to add to the master pods.
+    ##
+    extraPodLabels: {}
     ## Parameters to configure the resources allocated to the master.
     ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     ## @param wazuh.master.resources.requests.cpu Minimum CPU assigned to the pod.
@@ -900,6 +909,9 @@ wazuh:
     ## @param wazuh.worker.annotations additional annotations set on deployment.
     ##
     annotations: {}
+    ## @param wazuh.worker.extraPodLabels Extra labels to add to the worker pods.
+    ##
+    extraPodLabels: {}
     ## Parameters to configure the resources allocated to the worker.
     ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     ## @param wazuh.worker.resources.requests.cpu Minimum CPU assigned to the pod.
@@ -1077,6 +1089,9 @@ agent:
 
   ## @param wazuh.agent.podAnnotations Extra annotations for the agent.
   podAnnotations: {}
+
+  ## @param wazuh.agent.extraPodLabels Extra labels to add to the agent pods.
+  extraPodLabels: {}
 
   ## Parameters to configure the resources allocated to the agent.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/


### PR DESCRIPTION
This MR/PR adds support extraPodLabels.

For example, I want to route KSM alerts to the security team for `owner: security`.  I need to set a label on each pod:

```
agent:
  enabled: true
  extraPodLabels:
    owner: security
dashboard:
  extraPodLabels:
    owner: security
indexer:
  extraPodLabels:
    owner: security
wazuh:
  master:
    extraPodLabels:
      owner: security
  worker:
    extraPodLabels:
      owner: security
```

This will easily allow me to do that using shared serviceMonitors/alertmanager for CPU/RAM/Disk.

Also ran this `pre-commit run helm-readme-generator --all-files` locally but a lot of items were broken so I didn't fix those  .