### PR TITLE
[bugfix] issue-109: The agent from the latest image wazuh/wazuh-agent:4.14.1 does not accept environment variables, loses settings, and cannot connect to the server

### DIFF
--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -1082,7 +1082,7 @@ agent:
   ## @param wazuh.agent.resources.limits.memory Maximum memory used by the pod.
   ##
   images:
-    repository: wazuh/wazuh-agent
+    repository: kinseii/wazuh-agent
     tag: "4.14.1"
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Fix issue: https://github.com/morgoved/wazuh-helm/issues/109

I suggest using my image for now, but in the future, we should probably create a group repository for images. It seems very likely that the image from opennix has been abandoned: https://github.com/pyToshka/docker-wazuh-agent/discussions/222