### PR TITLE
Make wazuh.authd optional

### DIFF
--- a/charts/wazuh/templates/agent/daemonset.yaml
+++ b/charts/wazuh/templates/agent/daemonset.yaml
@@ -87,11 +87,13 @@ spec:
               value: {{ or .Values.agent.joinManager.workerHost (printf "%s-manager-worker.%s.svc.cluster.local" (include "wazuh.fullname" .) .Release.Namespace) }}
             - name: WAZUH_REGISTRATION_SERVER
               value: {{ or .Values.agent.joinManager.managerHost (printf "%s.%s.svc.cluster.local" (include "wazuh.fullname" .) .Release.Namespace) }}
+            {{- if .Values.wazuh.authd.enabled }}
             - name: WAZUH_REGISTRATION_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.wazuh.authd.existingSecret | default "wazuh-authd-pass" }}
                   key: authd.pass
+            {{- end }}
             - name: JOIN_MANAGER_PROTOCOL
               value: {{ .Values.agent.joinManager.scheme }}
             - name: JOIN_MANAGER_MASTER_HOST

--- a/charts/wazuh/templates/manager/secret-authd-pass.yaml
+++ b/charts/wazuh/templates/manager/secret-authd-pass.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.wazuh.enabled }}
+{{- if .Values.wazuh.authd.enabled }}
 {{- if not .Values.wazuh.authd.existingSecret }}
 apiVersion: v1
 kind: Secret
@@ -7,5 +8,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   authd.pass: {{ .Values.wazuh.authd.pass | default (randAlphaNum 16) | b64enc }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -712,10 +712,12 @@ wazuh:
     username: "wazuh-wui"
     password: "MyS3cr37P450r.*-"
   ## Parameters to the authd service.
+  ## @param wazuh.authd.enabled enable password-based agent registration (required if not using API-based enrollment).
   ## @param wazuh.authd.existingSecret name of the existingSecret in the namespace.
   ## @param wazuh.authd.pass password of the authd.
   ##
   authd:
+    enabled: true
     existingSecret: ""
     pass: "password"
   ## Parameters for the resources of the initContainer.


### PR DESCRIPTION
If I want to deploy only the agent in API auto-authentication mode and disable all components, the daemonset complains about the absence of the authd secret. 