### PR TITLE
#131, #74 - support changing the indexer job annotations to support argo

### DIFF
--- a/charts/wazuh/templates/indexer/job.yaml
+++ b/charts/wazuh/templates/indexer/job.yaml
@@ -3,8 +3,12 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   annotations:
+    {{- if .Values.indexer.job.annotations }}
+    {{- toYaml .Values.indexer.job.annotations | nindent 4 }}
+    {{- else }}
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    {{- end }}
   name: {{ include "wazuh.indexer.fullname" . }}-indexer
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -310,6 +310,16 @@ indexer:
     pod: {}
     container: {}
 
+  ## Override the indexer job annotations from the default Helm hooks
+  ## @param indexer.job.annotations Annotations to add to the indexer job.
+  ## Example:
+  ## job:
+  ##   annotations:
+  ##     argocd.argoproj.io/hook: PostSync
+  ##     argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
+  job:
+    annotations: {}
+
 ## @section indexer configuration of the wazuh dashboard. Kibana for elasticsearch with Wazuh plugins
 ## pre-installed
 ##


### PR DESCRIPTION
Adds the ability to modify the indexer job annotations to support ArgoCD.

When values set to new default:

```yaml
indexer:
  job:
    annotations: {}
```

results in (no change/which is what we want):

```yaml
---
# Source: wazuh/templates/indexer/job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  annotations:
    helm.sh/hook: post-install,post-upgrade
    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
  name: wazuh-indexer
  namespace: default
```

When values set to:

```yaml
indexer:
  job:
    annotations:
      argocd.argoproj.io/hook: PostSync
      argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
```

results in:

```yaml
---
# Source: wazuh/templates/indexer/job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  annotations:
    argocd.argoproj.io/hook: PostSync
    argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
  name: wazuh-indexer
  namespace: default
```

