### PR TITLE
feat: add variable for update-index init container image

### DIFF
--- a/charts/wazuh/README.md
+++ b/charts/wazuh/README.md
@@ -191,6 +191,7 @@ Same applies when changing `dashboard.cred.password`
 | `wazuh.apiCred.password`                        | password of the user. Note that the password must have a length                   | `MyS3cr37P450r.*-`                         |
 | `wazuh.authd.existingSecret`                    | name of the existingSecret in the namespace.                                      | `""`                                       |
 | `wazuh.authd.pass`                              | password of the authd.                                                            | `password`                                 |
+| `wazuh.initContainer.image`                     | Image used by the update-index container                                          | `alpine`                                   |
 | `wazuh.initContainer.resources.requests.cpu`    | Minimum CPU assigned to the pod.                                                  | `250m`                                     |
 | `wazuh.initContainer.resources.requests.memory` | Minimum memory assigned to the pod.                                               | `512Mi`                                    |
 | `wazuh.initContainer.resources.limits.cpu`      | Maximum CPU used by the pod.                                                      | `1000m`                                    |

--- a/charts/wazuh/templates/manager/master/statefulset.yaml
+++ b/charts/wazuh/templates/manager/master/statefulset.yaml
@@ -83,7 +83,7 @@ spec:
       {{- end }}
       initContainers:
         - name: update-index
-          image: alpine
+          image: {{ .Values.wazuh.initContainer.image }}
           imagePullPolicy: {{ .Values.wazuh.images.pullPolicy }}
           command: 
             - 'sh'

--- a/charts/wazuh/templates/manager/worker/statefulset.yaml
+++ b/charts/wazuh/templates/manager/worker/statefulset.yaml
@@ -98,7 +98,7 @@ spec:
         fsGroup: 101
       initContainers:
         - name: update-index
-          image: alpine
+          image: {{ .Values.wazuh.initContainer.image }}
           imagePullPolicy: {{ .Values.wazuh.images.pullPolicy }}
           command: 
             - 'sh'

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -735,11 +735,13 @@ wazuh:
     pass: "password"
   ## Parameters for the resources of the initContainer.
   ## @param wazuh.initContainer.resources.requests.cpu Minimum CPU assigned to the pod.
+  ## @param wazuh.initContainer.image Image used by the update-index container
   ## @param wazuh.initContainer.resources.requests.memory Minimum memory assigned to the pod.
   ## @param wazuh.initContainer.resources.limits.cpu Maximum CPU used by the pod.
   ## @param wazuh.initContainer.resources.limits.memory Maximum memory used by the pod.
   ##
   initContainer:
+    image: alpine
     resources:
       requests:
         cpu: 250m


### PR DESCRIPTION
I've added a new variable in order to override update-index init container image.
This would allow to pin a specific tag or use a custom image.
Yet, this only add one variable, other attributes remains unchanged.