### PR TITLE
Fixing password generation for wazuh api

### DIFF
--- a/charts/wazuh/templates/agent/secret-api-cred.yaml
+++ b/charts/wazuh/templates/agent/secret-api-cred.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   API_USERNAME: {{ .Values.agent.apiCred.username | default (randAlphaNum 10) | b64enc }}
-  API_PASSWORD: {{ .Values.agent.apiCred.password | default (randAlphaNum 16) | b64enc }}
+  API_PASSWORD: {{ .Values.agent.apiCred.password | default (printf "%s%s%s!%s" (randAlpha 1 | upper) (randAlpha 1 | lower) (randNumeric 1) (randAlphaNum 13)) | b64enc | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/wazuh/templates/manager/secret-api-cred.yaml
+++ b/charts/wazuh/templates/manager/secret-api-cred.yaml
@@ -7,6 +7,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   API_USERNAME: {{ .Values.wazuh.apiCred.username | default (randAlphaNum 10) | b64enc }}
-  API_PASSWORD: {{ .Values.wazuh.apiCred.password | default (randAlphaNum 16) | b64enc }}
+  API_PASSWORD: {{ .Values.wazuh.apiCred.password | default (printf "%s%s%s!%s" (randAlpha 1 | upper) (randAlpha 1 | lower) (randNumeric 1) (randAlphaNum 13)) | b64enc | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
If username and password are left empty for apiCred:
```
  apiCred:
    existingSecret: ""
    username: ""
    password: ""
```

The user's password is generated using `randAlphaNum 16`, which does not guarantee that the password meets the requirements of the security.py script:
```
_user_password = re.compile(r'^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$')
```

This results in an error:
```
Traceback (most recent call last):
  File "/var/ossec/framework/scripts/create_user.py", line 77, in <module>
    create_user(username=username, password=password)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/rbac/decorators.py", line 497, in wrapper
    result = func(*args, **kwargs) if not skip_execution else None
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/security.py", line 179, in create_user
    raise WazuhError(5007)
wazuh.core.exception.WazuhError: Error 5007 - Insecure user password provided
There was an error configuring the API user
```

My suggestion is to replace the generation with:
```
default (printf "%s%s%s!%s" (randAlpha 1 | upper) (randAlpha 1 | lower) (randNumeric 1) (randAlphaNum 13)) | b64enc | quote
```
This is an example, but it is functional.