### PR TITLE
Fix external indexer hostname

### DIFF
--- a/charts/wazuh/templates/_helpers.tpl
+++ b/charts/wazuh/templates/_helpers.tpl
@@ -816,7 +816,7 @@ wazuh_clusterd.debug=0
       <host>https://{{ include "wazuh.indexer.fullname" . }}-indexer:{{ .Values.indexer.service.httpPort }}</host>
     {{- end }}
     {{- if .Values.externalIndexer.enabled }}
-      <host>https://{{ .Values.externalIndexer.host }}:{{ .Values.externalIndexer.port }}</host>
+      <host>{{ .Values.externalIndexer.host }}:{{ .Values.externalIndexer.port }}</host>
     {{- end }}
     </hosts>
     <ssl>
@@ -1184,7 +1184,7 @@ wazuh_clusterd.debug=0
       <host>https://{{ include "wazuh.indexer.fullname" . }}-indexer:{{ .Values.indexer.service.httpPort }}</host>
     {{- end }}
     {{- if .Values.externalIndexer.enabled }}
-      <host>https://{{ .Values.externalIndexer.host }}:{{ .Values.externalIndexer.port }}</host>
+      <host>{{ .Values.externalIndexer.host }}:{{ .Values.externalIndexer.port }}</host>
     {{- end }}
     </hosts>
     <ssl>


### PR DESCRIPTION
The https prefix in _helpers.tpl breaks the ossec.conf configuration for manager and worker, because the protocol is duplicated in values, as in the example:
```
  <indexer>
    <enabled>yes</enabled>
    <hosts>
      <host>https://https://external-indexer:9200</host>
    </hosts>
  </indexer>
```