### PR TITLE
nfs storage for backups

### DIFF
--- a/charts/wazuh/templates/_helpers.tpl
+++ b/charts/wazuh/templates/_helpers.tpl
@@ -1473,6 +1473,9 @@ plugins.security.restapi.roles_enabled:
 plugins.security.allow_default_init_securityindex: true
 cluster.routing.allocation.disk.threshold_enabled: false
 compatibility.override_main_response_version: true
+{{- if .Values.indexer.snapshot.enabled }}
+path.repo: ["{{ .Values.indexer.snapshot.fs.path }}"]
+{{- end }}
 {{- end }}
 
 {{- define "wazuh.indexer.internalUsers"}}

--- a/charts/wazuh/templates/indexer/snapshot-pvc.yaml
+++ b/charts/wazuh/templates/indexer/snapshot-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.indexer.enabled .Values.indexer.snapshot.enabled (not .Values.indexer.snapshot.fs.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "wazuh.indexer.fullname" . }}-indexer-snapshots
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "wazuh.indexer.fullname" . }}-indexer
+spec:
+  accessModes:
+    {{- toYaml .Values.indexer.snapshot.fs.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.indexer.snapshot.fs.storageSize }}
+  {{- with .Values.indexer.snapshot.fs.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/wazuh/templates/indexer/statefulset.yaml
+++ b/charts/wazuh/templates/indexer/statefulset.yaml
@@ -135,6 +135,11 @@ spec:
         configMap:
           name: {{ include "wazuh.indexer.fullname" . }}-indexer-config
           defaultMode: 0600
+      {{- if .Values.indexer.snapshot.enabled }}
+      - name: snapshot-repo
+        persistentVolumeClaim:
+          claimName: {{ .Values.indexer.snapshot.fs.existingClaim | default (printf "%s-indexer-snapshots" (include "wazuh.indexer.fullname" .)) }}
+      {{- end }}
       {{- with .Values.indexer.additionalVolumes }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
@@ -260,6 +265,10 @@ spec:
               readOnly: true
             {{- with .Values.indexer.additionalVolumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.indexer.snapshot.enabled }}
+            - mountPath: {{ .Values.indexer.snapshot.fs.path }}
+              name: snapshot-repo
             {{- end }}
           ports:
             - containerPort: {{ .Values.indexer.service.httpPort }}

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -323,6 +323,35 @@ indexer:
     pod: {}
     container: {}
 
+  ## @section indexer.snapshot Configuration for OpenSearch snapshot repositories.
+  ## Ref: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/
+  ##
+  snapshot:
+    ## @param indexer.snapshot.enabled Enable snapshot repository configuration on the indexer.
+    ##
+    enabled: false
+    ## @param indexer.snapshot.fs.path Path inside the container where snapshots are stored.
+    ## This path is set as path.repo in opensearch.yml and must be accessible by all indexer nodes.
+    ##
+    fs:
+      path: /mnt/snapshots
+      ## @param indexer.snapshot.fs.storageSize Size of the PVC used for the snapshot volume.
+      ##
+      storageSize: 50Gi
+      ## @param indexer.snapshot.fs.storageClass StorageClass for the snapshot PVC.
+      ## Must support ReadWriteMany access mode (e.g. azurefile, azurefile-csi, efs-sc, nfs-client).
+      ## Standard block storage (managed-csi, gp3, etc.) will NOT work.
+      ##
+      storageClass: ""
+      ## @param indexer.snapshot.fs.accessModes Access modes for the snapshot PVC.
+      ##
+      accessModes:
+        - ReadWriteMany
+      ## @param indexer.snapshot.fs.existingClaim Name of an existing PVC to use instead of creating one.
+      ## If set, storageSize, storageClass, and accessModes are ignored.
+      ##
+      existingClaim: ""
+
   ## Override the indexer job annotations from the default Helm hooks
   ## @param indexer.job.annotations Annotations to add to the indexer job.
   ## Example:


### PR DESCRIPTION
@morgoved  This PR fix backup of indexer using nfs storage. It will for all public cloud later we can add S3, Azure and GCP Storages as well 

https://github.com/morgoved/wazuh-helm/issues/146 