### PR TITLE
fix: correct .helmignore typos and reduce chart package size by ~85%

### DIFF
--- a/charts/wazuh/.helmignore
+++ b/charts/wazuh/.helmignore
@@ -19,9 +19,14 @@
 .project
 .idea/
 *.tmproj
-# img folder
-img/
+# images folder
+images/
 # Changelog
 CHANGELOG.md
-
+# README
+README.md
+# License
+LICENSE
+# example folder
+example/
 wazuh-*.tgz


### PR DESCRIPTION
## Summary

Fix the `images/` exclusion typo (currently `img/`) and add a few
additional documentation entries to `.helmignore`.

## Motivation

The current `.helmignore` includes `img/` with the comment "img folder",
but the actual chart directory is `images/`. As a result, the documentation
PNGs are not being excluded from the packaged chart and are bundled into
every Helm release.

This causes the chart package to be ~1.3 MB, of which roughly 73% is
documentation imagery:

| File                          | Size       |
|-------------------------------|-----------:|
| `images/dashboard.png`        | 426,900 B  |
| `images/threat-hunting.png`   | 267,284 B  |
| `images/agent-deploy.png`     | 261,880 B  |
| `images/icon.png`             |  20,808 B  |
| `README.md`                   |  49,552 B  |
| `example/values.yaml`         |  49,108 B  |
| `LICENSE`                     |  15,144 B  |
| **Total documentation**       | **~1.0 MB** |

After Helm gzips the release for storage in a Kubernetes Secret,
the secret can exceed the 1 MiB Kubernetes Secret size limit
(`data: Too long: must have at most 1048576 bytes`). When this
happens, no further `helm upgrade` operations succeed — the API
server rejects the new release secret.

This affects deployments using GitOps controllers (Flux's helm-controller,
ArgoCD) where upgrades fail silently and configmaps drift away from
the values declared in source control.

In our case, this caused values.yaml changes to silently not deploy
for several weeks before we caught it.

Before: 1.3 MB packaged chart (1.5 MB release secret with overhead)
After:  174 KB packaged chart (~85% reduction)

## What this PR changes

1. Fix the existing `img/` typo to match the actual `images/` directory
2. Add `README.md` and `LICENSE` (consistent with the existing `CHANGELOG.md` exclusion)
3. Add `example/` for the example sub-charts and values

```diff
# - img/
# + images/
# + # README
# + README.md
# + # License
# + LICENSE
# + # example folder
# + example/
```

## Verification

Before:

    $ helm package . && ls -lh wazuh-*.tgz
    -rw-r--r--  ~340K wazuh-1.0.20.tgz   # compressed
    $ tar -tzf wazuh-1.0.20.tgz | grep -E 'images|README|LICENSE|example' | head
    wazuh/images/dashboard.png
    wazuh/images/threat-hunting.png
    wazuh/images/agent-deploy.png
    wazuh/images/icon.png
    wazuh/README.md
    wazuh/LICENSE
    wazuh/example/dashboard-certs/Chart.yaml
    ...

After:

    $ helm package . && ls -lh wazuh-*.tgz
    -rw-r--r--  ~50K wazuh-1.0.20.tgz   # ~85% smaller
    $ tar -tzf wazuh-1.0.20.tgz | grep -E 'images|README|LICENSE|example'
    (no output)

## Impact assessment

**No functional change.** Documentation assets are excluded from the
packaged chart only. The repository structure, GitHub README, example
sub-charts, LICENSE, and images all remain in source control — they're
visible to anyone browsing the chart on GitHub.

The chart's templates, helpers, values schema, and CRDs are unchanged.
All existing deployments continue to work identically.

## Backwards compatibility

Fully backwards-compatible. Users pulling the chart get the same
templates and helpers; they just receive a smaller archive.