### PR TITLE
chore: bump chart version to 1.0.23 to publish helmignore fix

### DIFF
--- a/charts/wazuh/Chart.yaml
+++ b/charts/wazuh/Chart.yaml
@@ -3,7 +3,7 @@ name: wazuh
 description: Wazuh is a free and open source security platform that unifies XDR and SIEM protection for endpoints and cloud workloads.
 type: application
 appVersion: 4.14.1
-version: 1.0.22
+version: 1.0.23
 annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/category: security


### PR DESCRIPTION
## Summary

Bump chart version to 1.0.23 so that the `.helmignore` fix from #162
gets published as a new release.

## Context

PR #162 was merged but the chart-releaser workflow failed because
`1.0.22` was already published as a GitHub release without the fix.
The workflow correctly refused to overwrite the existing release.

This PR bumps the chart version so the next workflow run publishes
the fix as `1.0.23`. After this merges, consumers running 
`helm repo update` will see the new version with the corrected
`.helmignore` and 174KB package size.

No code changes — only `Chart.yaml` version bump.

cc @morgoved — follow-up to land #162.