### PR TITLE
refactor(manager): update config volume permissions to read and execute only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wazuh-kubernetes-helm-chart
 
-![Version: 1.0.22](https://img.shields.io/badge/Version-1.0.22-informational?style=flat-square)
+![Version: 1.0.23](https://img.shields.io/badge/Version-1.0.23-informational?style=flat-square)
 ![AppVersion: 4.14.1](https://img.shields.io/badge/AppVersion-4.14.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/wazuh-helm-morgoved)](https://artifacthub.io/packages/search?repo=wazuh-helm-morgoved)
 

--- a/charts/wazuh/Chart.yaml
+++ b/charts/wazuh/Chart.yaml
@@ -3,7 +3,7 @@ name: wazuh
 description: Wazuh is a free and open source security platform that unifies XDR and SIEM protection for endpoints and cloud workloads.
 type: application
 appVersion: 4.14.1
-version: 1.0.22
+version: 1.0.23
 annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/category: security

--- a/charts/wazuh/README.md
+++ b/charts/wazuh/README.md
@@ -1,7 +1,8 @@
 # wazuh
 
-![Version: 1.0.22](https://img.shields.io/badge/Version-1.0.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.14.1](https://img.shields.io/badge/AppVersion-4.14.1-informational?style=flat-square)
+![Version: 1.0.23](https://img.shields.io/badge/Version-1.0.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.14.1](https://img.shields.io/badge/AppVersion-4.14.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/wazuh-helm-morgoved)](https://artifacthub.io/packages/search?repo=wazuh-helm-morgoved)
+
 ## Introduction
 
 Wazuh is a free and open source security platform that unifies XDR and SIEM protection for endpoints and cloud workloads.
@@ -237,6 +238,7 @@ Same applies when changing `dashboard.cred.password`
 | `wazuh.master.extraConf`                           | Gets appended to the wazuh.master.conf.                      | `""`                                   |
 | `wazuh.master.dnsPolicy`                           | DNS policy for the pod.                                      | `""`                                   |
 | `wazuh.master.dnsConfig`                           | DNS configuration for the pod.                               | `{}`                                   |
+| `wazuh.master.configVolume.defaultMode`            | Allow to customize defaultMode of config volume              | `0777`                                 |
 
 ### wazuh.worker configuration of the wazuh worker component.
 
@@ -265,6 +267,7 @@ Same applies when changing `dashboard.cred.password`
 | `wazuh.worker.extraConf`                          | Gets appended to the wazuh.worker.conf.                      | `""`                                   |
 | `wazuh.worker.dnsPolicy`                          | DNS policy for the pod.                                      | `""`                                   |
 | `wazuh.worker.dnsConfig`                          | DNS configuration for the pod.                               | `{}`                                   |
+| `wazuh.worker.configVolume.defaultMode`           | Allow to customize defaultMode of config volume              | `0777`                                 |
 
 ### agent configuration of the wazuh agent component.
 

--- a/charts/wazuh/templates/manager/master/statefulset.yaml
+++ b/charts/wazuh/templates/manager/master/statefulset.yaml
@@ -69,7 +69,7 @@ spec:
         - name: config
           configMap:
             name: {{ template "wazuh.fullname" . }}-manager-config
-            defaultMode: 0777
+            defaultMode: 0640
         - name: filebeat-certs
           secret:
             secretName: filebeat-tls

--- a/charts/wazuh/templates/manager/master/statefulset.yaml
+++ b/charts/wazuh/templates/manager/master/statefulset.yaml
@@ -69,7 +69,7 @@ spec:
         - name: config
           configMap:
             name: {{ template "wazuh.fullname" . }}-manager-config
-            defaultMode: 0640
+            defaultMode: 0500
         - name: filebeat-certs
           secret:
             secretName: filebeat-tls

--- a/charts/wazuh/templates/manager/master/statefulset.yaml
+++ b/charts/wazuh/templates/manager/master/statefulset.yaml
@@ -69,7 +69,7 @@ spec:
         - name: config
           configMap:
             name: {{ template "wazuh.fullname" . }}-manager-config
-            defaultMode: 0500
+            defaultMode: {{ default "0500" .Values.wazuh.master.configVolume.defaultMode }}
         - name: filebeat-certs
           secret:
             secretName: filebeat-tls

--- a/charts/wazuh/templates/manager/worker/statefulset.yaml
+++ b/charts/wazuh/templates/manager/worker/statefulset.yaml
@@ -85,7 +85,7 @@ spec:
         - name: config
           configMap:
             name: {{ include "wazuh.fullname" . }}-manager-config
-            defaultMode: 0777
+            defaultMode: 0640
         - name: filebeat-certs
           secret:
             secretName: filebeat-tls

--- a/charts/wazuh/templates/manager/worker/statefulset.yaml
+++ b/charts/wazuh/templates/manager/worker/statefulset.yaml
@@ -85,7 +85,7 @@ spec:
         - name: config
           configMap:
             name: {{ include "wazuh.fullname" . }}-manager-config
-            defaultMode: 0500
+            defaultMode: {{ default "0500" .Values.wazuh.worker.configVolume.defaultMode }}
         - name: filebeat-certs
           secret:
             secretName: filebeat-tls

--- a/charts/wazuh/templates/manager/worker/statefulset.yaml
+++ b/charts/wazuh/templates/manager/worker/statefulset.yaml
@@ -85,7 +85,7 @@ spec:
         - name: config
           configMap:
             name: {{ include "wazuh.fullname" . }}-manager-config
-            defaultMode: 0640
+            defaultMode: 0500
         - name: filebeat-certs
           secret:
             secretName: filebeat-tls

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -911,6 +911,15 @@ wazuh:
           targetPort: 55000
           # nodePort: 31550
 
+    ## @param wazuh.master.configVolume
+    ## Allow to override defaultMode for config volume.
+    ## If not present in values.yaml, it will default to 0500.
+    ## Example:
+    ## configVolume:
+    ##   defaultMode: 0500
+    configVolume:
+      defaultMode: "0777"
+
     ## @param wazuh.master.livenessProbe Parameter to configure the livenessProbe.
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
     ## TODO
@@ -1026,6 +1035,15 @@ wazuh:
     ##     - name: ndots
     ##       value: "2"
     dnsConfig: {}
+
+    ## @param wazuh.worker.configVolume
+    ## Allow to override defaultMode for config volume.
+    ## If not present in values.yaml, it will default to 0500.
+    ## Example:
+    ## configVolume:
+    ##   defaultMode: 0500
+    configVolume:
+      defaultMode: "0777"
 
     ## Pod anti-affinity can prevent the scheduler from placing Alertmanager replicas on the same node.
     ## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.


### PR DESCRIPTION
current pemissions for config volume `0777` is too permissive. Reducing it to `0500`.
Deployment has been tested on a small minikube instance. To use similar environment use the following command:
```bash
 minikube start --driver=kvm2 --cpus 6 --memory 8192 --disk-size=100g --addons=metrics-server,csi-hostpath-driver,volumesnapshot
```