### PR TITLE
Add the same securityContext of indexer StatefulSet to indexer Job CR

### DIFF
--- a/charts/wazuh/templates/indexer/job.yaml
+++ b/charts/wazuh/templates/indexer/job.yaml
@@ -42,6 +42,10 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- with .Values.indexer.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - command:
             - sh


### PR DESCRIPTION
In openshift, need add the same securityContext of indexer StatefulSet to indexer Job CR, otherwise it reports permission issue on file /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh when the job pod starts up.