### PR TITLE
fix(manager): name master API Service after the chart fullname

### DIFF
--- a/charts/wazuh/templates/manager/master/service.yaml
+++ b/charts/wazuh/templates/manager/master/service.yaml
@@ -2,8 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  # Name is only "wazuh" because of Certificates commonName
-  name: wazuh
+  name: {{ include "wazuh.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "wazuh.fullname" . }}-manager


### PR DESCRIPTION
The master Service was hardcoded to `wazuh` while every consumer (dashboard WAZUH_API_URL, agent WAZUH_REGISTRATION_SERVER/JOIN_MANAGER_MASTER_HOST) targets the chart fullname. This broke the dashboard API check and agent enrollment for any release not named `wazuh`. Backward-compatible: for a release named `wazuh`, fullname==wazuh so the Service name is unchanged.

Link to #168