### PR TITLE
fix(indexer): remove duplicate pod securityContext in indexer Job template

### DIFF
--- a/charts/wazuh/Chart.yaml
+++ b/charts/wazuh/Chart.yaml
@@ -3,7 +3,7 @@ name: wazuh
 description: Wazuh is a free and open source security platform that unifies XDR and SIEM protection for endpoints and cloud workloads.
 type: application
 appVersion: 4.14.3
-version: 2.0.2
+version: 2.0.3
 annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/category: security

--- a/charts/wazuh/templates/indexer/job.yaml
+++ b/charts/wazuh/templates/indexer/job.yaml
@@ -132,8 +132,6 @@ spec:
               mountPath: /usr/share/wazuh-indexer/config/opensearch-security/whitelist.yml
               subPath: whitelist.yml
               readOnly: true
-      securityContext:
-        fsGroup: 1000
       terminationGracePeriodSeconds: 30
       volumes:
         - name: admin-certs


### PR DESCRIPTION
### Problem

`templates/indexer/job.yaml` renders the pod-level `securityContext` **twice**:

- once from `.Values.indexer.securityContext` (default `values.yaml` sets `{fsGroup: 1000}`), and
- once hardcoded a few lines later:

```yaml
      securityContext:
        fsGroup: 1000
```

This produces a Job manifest whose pod spec has a duplicate `securityContext:` mapping key. `helm template`/`helm install` tolerate it (last key wins), so it goes unnoticed with plain Helm. But any strict YAML consumer rejects it. In particular `kustomize build --enable-helm` (the Kustomize Helm chart inflation generator) fails hard:

```
Error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 114: mapping key "securityContext" already defined at line 23
```

Present on `main` and in released `2.0.0`–`2.0.2`. The indexer `Job` is the only affected object.

### Fix

Remove the redundant hardcoded block. The values-driven block (`{{- with .Values.indexer.securityContext }}`) already emits `fsGroup: 1000` via the chart default, so rendered output is **unchanged** for default installs — it just no longer appears twice. As a bonus, `--set indexer.securityContext=null` now actually removes the block instead of leaving the hardcoded leftover.

### Verification

Default install (unchanged):

```yaml
      securityContext:
        fsGroup: 1000
```

`-f` with `indexer: {securityContext: null}` now renders **no** pod `securityContext` (previously still emitted the hardcoded one). `kustomize build --enable-helm` succeeds against the patched chart.

Chart version bumped `2.0.2` → `2.0.3`.
